### PR TITLE
Update path expression

### DIFF
--- a/OSXFUSE/osxfuse.pkg.recipe
+++ b/OSXFUSE/osxfuse.pkg.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>source_pkg</key>
-                <string>%pathname%/Extras/FUSE for OS X *.pkg</string>
+                <string>%pathname%/Extras/FUSE for macOS *.pkg</string>
 		<key>pkg_path</key>
 		<string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
             </dict>


### PR DESCRIPTION
The path to the OS X (sic) pkg file has changed from OS X to macOS.
Update the regular expression to reflect this.
