### PR TITLE
MacFUSE compatibility layer and OSXFUSE 3

### DIFF
--- a/OSXFUSE/osxfuse.munki.recipe
+++ b/OSXFUSE/osxfuse.munki.recipe
@@ -36,6 +36,14 @@
 			    <key>choiceIdentifier</key>
 			    <string>%OS_VERSION%$OSXFUSEMacFUSE</string>
 		    </dict>
+		    <dict>
+			    <key>attributeSetting</key>
+			    <integer>1</integer>
+			    <key>choiceAttribute</key>
+			    <string>selected</string>
+			    <key>choiceIdentifier</key>
+			    <string>com.github.osxfuse.pkg.MacFUSE</string>
+		    </dict>
 	    </array>
         </dict>
     </dict>


### PR DESCRIPTION
OSXFUSE 3 renames the choice identifier of the MacFUSE compatibility layer from e.g. `10.9OSXFUSEMacFUSE` to `com.github.osxfuse.pkg.MacFUSE`. I've added it to the list of choice changes -- installer simply ignores choice changes for which it can't find the package. Once OSXFUSE 3 is out of beta, the old identifier will no longer be needed.
