### PR TITLE
OSXFUSE prefpane appears to no longer be selected by default

### DIFF
--- a/OSXFUSE/osxfuse.munki.recipe
+++ b/OSXFUSE/osxfuse.munki.recipe
@@ -44,6 +44,14 @@
 			    <key>choiceIdentifier</key>
 			    <string>com.github.osxfuse.pkg.MacFUSE</string>
 		    </dict>
+		    <dict>
+			    <key>attributeSetting</key>
+			    <integer>1</integer>
+			    <key>choiceAttribute</key>
+			    <string>selected</string>
+			    <key>choiceIdentifier</key>
+			    <string>com.github.osxfuse.pkg.PrefPane</string>
+		    </dict>
 	    </array>
         </dict>
     </dict>


### PR DESCRIPTION
When installing OSXFUSE on macOS 10.13, it seems like the PrefPane is no longer installed by default. Because Munki still expects it to be installed, this causes it to install OSXFUSE over and over. This pull request adds a choice change for the PrefPane to always install it.