### PR TITLE
Update URLProvider processors to use URLGetter

### DIFF
--- a/Emacs/EmacsURLProvider.py
+++ b/Emacs/EmacsURLProvider.py
@@ -17,47 +17,42 @@
 
 from __future__ import absolute_import
 
-import subprocess
 import xml.etree.ElementTree as ET
 
-from autopkglib import Processor, ProcessorError
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["EmacsURLProvider"]
 
 check_url = "https://emacsformacosx.com/atom/release"
 
 
-class EmacsURLProvider(Processor):
+class EmacsURLProvider(URLGetter):
     """This processor obtains a download URL for the latest version of GNU Emacs for OSX"""
+
     description = __doc__
-    input_variables = {
-    }
+    input_variables = {}
     output_variables = {
-        "url": {
-            "description": "URL to latest version of the product.",
-        },
+        "url": {"description": "URL to latest version of the product.",},
     }
 
     def main(self):
         """Provide a download URL for GNU Emacs for OSX"""
         # Get the xml file of updates
         try:
-            xmldata = subprocess.check_output(('/usr/bin/curl',
-                                               '--silent',
-                                               '--location',
-                                               check_url))
+            xmldata = self.download(check_url)
         except BaseException as err:
             raise ProcessorError("Can't download %s: %s" % (check_url, err))
 
         # Grab the first download link of the right type
         root = ET.fromstring(xmldata)
-        for link in root.iter('{http://www.w3.org/2005/Atom}link'):
-            if link.attrib['type'] == 'binary/octet-stream':
-                url = link.attrib['href']
+        for link in root.iter("{http://www.w3.org/2005/Atom}link"):
+            if link.attrib["type"] == "binary/octet-stream":
+                url = link.attrib["href"]
                 break
 
         self.env["url"] = url
         self.output("Found URL as %s" % self.env["url"])
+
 
 if __name__ == "__main__":
     PROCESSOR = EmacsURLProvider()

--- a/yWorks/YWorksURLProvider.py
+++ b/yWorks/YWorksURLProvider.py
@@ -17,29 +17,23 @@
 
 from __future__ import absolute_import
 
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib.request import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["YWorksURLProvider"]
 
-class YWorksURLProvider(Processor):
+
+class YWorksURLProvider(URLGetter):
     """This processor obtains a download URL for the latest version of yWorks"""
+
     description = __doc__
     input_variables = {
         "product_name": {
             "required": True,
-            "description":
-                "Product to fetch URL for. Right now, only 'yEd'.",
+            "description": "Product to fetch URL for. Right now, only 'yEd'.",
         },
     }
     output_variables = {
-        "url": {
-            "description": "URL to latest version of the given product.",
-        },
+        "url": {"description": "URL to latest version of the given product.",},
     }
 
     def main(self):
@@ -47,22 +41,31 @@ class YWorksURLProvider(Processor):
         product_name = self.env["product_name"]
         # http://www.yworks.com/products/yed/demo/yEd-CurrentVersion.txt
         base_url = "http://www.yworks.com/products"
-        check_url = "%s/%s/demo/%s-CurrentVersion.txt" % (base_url, product_name.lower(), product_name)
+        check_url = "%s/%s/demo/%s-CurrentVersion.txt" % (
+            base_url,
+            product_name.lower(),
+            product_name,
+        )
+        print(check_url)
 
         # Get the text file
         try:
-            fref = urlopen(check_url)
-            txt = fref.read()
-            fref.close()
+            txt = self.download(check_url)
         except BaseException as err:
             raise ProcessorError("Can't download %s: %s" % (check_url, err))
 
         # Create download link
         latest = txt.rstrip()
         base_prod_url = "http://www.yworks.com/products"
-        download_url = "%s/%s/demo/%s-%s_with-JRE10.dmg" % (base_prod_url, product_name.lower(), product_name, latest)
+        download_url = "%s/%s/demo/%s-%s_with-JRE10.dmg" % (
+            base_prod_url,
+            product_name.lower(),
+            product_name,
+            latest,
+        )
         self.env["url"] = download_url
         self.output("Found URL as %s" % self.env["url"])
+
 
 if __name__ == "__main__":
     PROCESSOR = YWorksURLProvider()


### PR DESCRIPTION
This PR adjusts the three custom URL provider processors in this repo to use the new [URLGetter superclass](https://github.com/autopkg/autopkg/wiki/Downloading-from-the-Internet-in-Custom-Processors), which will ease the transition to Python 3 and AutoPkg 2.

AutoPkg run log for the recipes that depend on the URL providers:
https://gist.github.com/homebysix/e7db41cc9d80a4a175e49d8bd8e9b2a1