### PR TITLE
Ensure YWorksURLProvider download result is string, not bytes

### DIFF
--- a/yWorks/YWorksURLProvider.py
+++ b/yWorks/YWorksURLProvider.py
@@ -50,7 +50,7 @@ class YWorksURLProvider(URLGetter):
 
         # Get the text file
         try:
-            txt = self.download(check_url)
+            txt = self.download(check_url, text=True)
         except BaseException as err:
             raise ProcessorError("Can't download %s: %s" % (check_url, err))
 


### PR DESCRIPTION
Slight tweak necessary for AutoPkg 2.0 compatibility in the YWorksURLProvider processor.