### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/SweetHome3D/SweetHome3D.download.recipe
+++ b/SweetHome3D/SweetHome3D.download.recipe
@@ -44,7 +44,7 @@
             <dict>
                 <key>input_path</key>
                 <string>%pathname%/Sweet Home 3D.app</string>
-                <key>requirements</key>
+                <key>requirement</key>
                 <string>identifier "com.eteks.sweethome3d.SweetHome3D" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = U3J5N84335</string>
             </dict>
         </dict>

--- a/yWorks/yEd.download.recipe
+++ b/yWorks/yEd.download.recipe
@@ -44,7 +44,7 @@
             <dict>
                 <key>input_path</key>
                 <string>%pathname%/yEd.app</string>
-                <key>requirements</key>
+                <key>requirement</key>
                 <string>identifier "com.yworks.yEd" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JD89S887M2</string>
             </dict>
         </dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.