### PR TITLE
Switch recipe maintainer on macFUSE recipes, deprecate these

### DIFF
--- a/macFUSE/macfuse.download.recipe
+++ b/macFUSE/macfuse.download.recipe
@@ -22,6 +22,15 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>warning_message</key>
+                <string>This recipe is no longer maintained. Please use the macFUSE recipes from https://github.com/autopkg/apizz-recipes instead.</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>include_prereleases</key>
                 <string>%INCLUDE_PRERELEASES%</string>
                 <key>github_repo</key>

--- a/macFUSE/macfuse.munki.recipe
+++ b/macFUSE/macfuse.munki.recipe
@@ -56,6 +56,15 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>warning_message</key>
+                <string>This recipe is no longer maintained. Please use the macFUSE recipes from https://github.com/autopkg/apizz-recipes instead.</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                 <key>installs_item_paths</key>

--- a/macFUSE/macfuse.munki.recipe
+++ b/macFUSE/macfuse.munki.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>macfuse</string>
         <key>MUNKI_REPO_SUBDIR</key>
-        <string>drivers</string>
+        <string>drivers/macfuse</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -21,11 +21,9 @@
             <key>description</key>
             <string>macFUSE allows you to extend OS X's native file handling capabilities via third-party file systems. macFUSE (v4) is a successor to OSXFUSE (v3), which has been used as a software building block by dozens of products, but is no longer being maintained.</string>
             <key>display_name</key>
-            <string>MACFUSE</string>
+            <string>macFUSE</string>
             <key>name</key>
             <string>%NAME%</string>
-            <key>unattended_install</key>
-            <true/>
             <key>installer_choices_xml</key>
             <array>
                 <dict>
@@ -45,6 +43,8 @@
                     <string>io.macfuse.installer.components.preferencepane</string>
                 </dict>
             </array>
+            <key>unattended_install</key>
+            <true/>
         </dict>
     </dict>
     <key>MinimumVersion</key>
@@ -56,6 +56,44 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Library/Filesystems/macfuse.fs</string>
+                    <string>/Library/Frameworks/macFUSE.framework</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Comment</key>
+            <string>Import items</string>
+            <key>Arguments</key>
+            <dict/>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Comment</key>
+            <string>Import version and min os version</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%min_os_version%</string>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>pkg_path</key>
                 <string>%pkg_path%</string>
                 <key>repo_subdirectory</key>
@@ -63,6 +101,20 @@
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Comment</key>
+            <string>Cleanup</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>

--- a/macFUSE/macfuse.pkg.recipe
+++ b/macFUSE/macfuse.pkg.recipe
@@ -18,8 +18,8 @@
     <key>Process</key>
     <array>
         <dict>
-        <key>Comment</key>
-        <string>Copy the pkg out of the DMG as it's flat and there's no need for the DMG</string>
+            <key>Comment</key>
+            <string>Copy the pkg out of the DMG as it's flat and there's no need for the DMG</string>
             <key>Arguments</key>
             <dict>
                 <key>source_pkg</key>

--- a/macFUSE/macfuse.pkg.recipe
+++ b/macFUSE/macfuse.pkg.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is no longer maintained. Please use the macFUSE recipes from https://github.com/autopkg/apizz-recipes instead.</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
             <key>Comment</key>
             <string>Copy the pkg out of the DMG as it's flat and there's no need for the DMG</string>
             <key>Arguments</key>

--- a/macFUSE/macfuse.pkg.recipe
+++ b/macFUSE/macfuse.pkg.recipe
@@ -23,12 +23,118 @@
             <key>Arguments</key>
             <dict>
                 <key>source_pkg</key>
-                <string>%pathname%/Extras/macFUSE *.pkg</string>
+                <string>%pathname%/Extras/macFUSE*.pkg</string>
                 <key>pkg_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
             </dict>
             <key>Processor</key>
             <string>PkgCopier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>flat_pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Comment</key>
+            <string>Unpack the Core PKG</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/Core.pkg/Payload</string>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Comment</key>
+            <string>Verify .fs code signature</string>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array/>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Library/Filesystems/macfuse.fs</string>
+                <key>requirement</key>
+                <string>identifier "io.macfuse.filesystems.fs.macfuse" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3T5GSNBU6W"</string>
+                <key>strict_verification</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+        <dict>
+            <key>Comment</key>
+            <string>Verify .framework code signature</string>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array/>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Library/Frameworks/macFUSE.framework</string>
+                <key>requirement</key>
+                <string>identifier "io.macfuse.frameworks.macfuse" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3T5GSNBU6W"</string>
+                <key>strict_verification</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+        <dict>
+            <key>Comment</key>
+            <string>Unpack the pref pane</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/PreferencePane.pkg/Payload</string>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
+        <dict>
+            <key>Comment</key>
+            <string>Verify .prefPane code signature</string>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array/>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Library/PreferencePanes/macFUSE.prefPane</string>
+                <key>requirement</key>
+                <string>identifier "io.macfuse.preferencepanes.macfuse" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3T5GSNBU6W"</string>
+                <key>strict_verification</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+        <dict>
+            <key>Comment</key>
+            <string>Get version and min os version</string>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Library/Filesystems/macfuse.fs/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
+                    <key>LSMinimumSystemVersion</key>
+                    <string>min_os_version</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
PKG run, which adds expansion of PKG to do additional codesignature verification and for use by later munki recipe:
```
autopkg run -vv ./macfuse.pkg.recipe                                                23:35:41
Processing ./macfuse.pkg.recipe...
WARNING: ./macfuse.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '^macfuse-.*dmg$',
           'github_repo': 'osxfuse/osxfuse',
           'include_prereleases': 'true'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '^macfuse-.*dmg$' among asset(s): macfuse-4.2.4-debug.tbz, macfuse-4.2.4.dmg, macfuse-4.2.4.sha256, macfuse-4.2.4.sha256.sig
GitHubReleasesInfoProvider: Selected asset 'macfuse-4.2.4.dmg' from release 'macFUSE 4.2.4'
{'Output': {'release_notes': '* Improve support for macOS 12. Starting with '
                             'macOS 12, the process `diskimagesiod` needs to '
                             'be able to access disk images in order for them '
                             'to be mounted. Allow `diskimagesiod` to access '
                             'the volume even if the `allow_other` mount '
                             'option has not been specified.\r\n'
                             '\r\n'
                             '* Use macOS 12.1 SDK to instead of macOS 11.3 '
                             'SDK to build macFUSE.',
            'url': 'https://github.com/osxfuse/osxfuse/releases/download/macfuse-4.2.4/macfuse-4.2.4.dmg',
            'version': 'macfuse-4.2.4'}}
URLDownloader
{'Input': {'url': 'https://github.com/osxfuse/osxfuse/releases/download/macfuse-4.2.4/macfuse-4.2.4.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/downloads/macfuse-4.2.4.dmg
{'Output': {'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/downloads/macfuse-4.2.4.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Benjamin '
                                        'Fleischer (3T5GSNBU6W)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/downloads/macfuse-4.2.4.dmg/Extras/macFUSE*.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/downloads/macfuse-4.2.4.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.VwwEvU/Extras/macFUSE 4.2.4.pkg' matched from globbed '/private/tmp/dmg.VwwEvU/Extras/macFUSE*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "macFUSE 4.2.4":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-12-20 15:58:39 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Benjamin Fleischer (3T5GSNBU6W)
CodeSignatureVerifier:        Expires: 2022-03-30 21:49:12 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            6F AD D6 59 BA 75 D1 0C 2F 4B 78 F5 36 56 48 A4 3F F4 68 2A 23 DC 
CodeSignatureVerifier:            25 B7 85 28 23 54 A7 06 39 A1
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
PkgCopier
{'Input': {'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE.pkg',
           'source_pkg': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/downloads/macfuse-4.2.4.dmg/Extras/macFUSE*.pkg'}}
PkgCopier: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/downloads/macfuse-4.2.4.dmg
PkgCopier: Using path '/private/tmp/dmg.vNCBae/Extras/macFUSE 4.2.4.pkg' matched from globbed '/private/tmp/dmg.vNCBae/Extras/macFUSE*.pkg'.
PkgCopier: Copied /private/tmp/dmg.vNCBae/Extras/macFUSE 4.2.4.pkg to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE.pkg'}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/unpack',
           'flat_pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE.pkg'}}
FlatPkgUnpacker: Unpacked /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE.pkg to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE',
           'pkg_payload_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/unpack/Core.pkg/Payload'}}
PkgPayloadUnpacker: Unpacked /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/unpack/Core.pkg/Payload to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': [],
           'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE/Library/Filesystems/macfuse.fs',
           'requirement': 'identifier "io.macfuse.filesystems.fs.macfuse" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"3T5GSNBU6W"',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE/Library/Filesystems/macfuse.fs: valid on disk
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE/Library/Filesystems/macfuse.fs: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE/Library/Filesystems/macfuse.fs: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': [],
           'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE/Library/Frameworks/macFUSE.framework',
           'requirement': 'identifier "io.macfuse.frameworks.macfuse" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"3T5GSNBU6W"',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE/Library/Frameworks/macFUSE.framework: valid on disk
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE/Library/Frameworks/macFUSE.framework: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE/Library/Frameworks/macFUSE.framework: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE',
           'pkg_payload_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/unpack/PreferencePane.pkg/Payload'}}
PkgPayloadUnpacker: Unpacked /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/unpack/PreferencePane.pkg/Payload to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': [],
           'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE/Library/PreferencePanes/macFUSE.prefPane',
           'requirement': 'identifier "io.macfuse.preferencepanes.macfuse" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"3T5GSNBU6W"',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE/Library/PreferencePanes/macFUSE.prefPane: valid on disk
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE/Library/PreferencePanes/macFUSE.prefPane: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE/Library/PreferencePanes/macFUSE.prefPane: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/receipts/macfuse.pkg-receipt-20220214-233628.plist

The following packages were copied:
    Pkg Path                                                                            
    --------                                                                            
    /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.pkg.macfuse/MACFUSE.pkg  
```

munki recipe, which uses `installs` array now instead of relying on PKG receipts:
```
autopkg run -vv ./macfuse.munki.recipe                                              23:57:06
Processing ./macfuse.munki.recipe...
WARNING: ./macfuse.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '^macfuse-.*dmg$',
           'github_repo': 'osxfuse/osxfuse',
           'include_prereleases': 'true'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '^macfuse-.*dmg$' among asset(s): macfuse-4.2.4-debug.tbz, macfuse-4.2.4.dmg, macfuse-4.2.4.sha256, macfuse-4.2.4.sha256.sig
GitHubReleasesInfoProvider: Selected asset 'macfuse-4.2.4.dmg' from release 'macFUSE 4.2.4'
{'Output': {'release_notes': '* Improve support for macOS 12. Starting with '
                             'macOS 12, the process `diskimagesiod` needs to '
                             'be able to access disk images in order for them '
                             'to be mounted. Allow `diskimagesiod` to access '
                             'the volume even if the `allow_other` mount '
                             'option has not been specified.\r\n'
                             '\r\n'
                             '* Use macOS 12.1 SDK to instead of macOS 11.3 '
                             'SDK to build macFUSE.',
            'url': 'https://github.com/osxfuse/osxfuse/releases/download/macfuse-4.2.4/macfuse-4.2.4.dmg',
            'version': 'macfuse-4.2.4'}}
URLDownloader
{'Input': {'url': 'https://github.com/osxfuse/osxfuse/releases/download/macfuse-4.2.4/macfuse-4.2.4.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/downloads/macfuse-4.2.4.dmg
{'Output': {'pathname': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/downloads/macfuse-4.2.4.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Benjamin '
                                        'Fleischer (3T5GSNBU6W)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/downloads/macfuse-4.2.4.dmg/Extras/macFUSE*.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/downloads/macfuse-4.2.4.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.zgx6hP/Extras/macFUSE 4.2.4.pkg' matched from globbed '/private/tmp/dmg.zgx6hP/Extras/macFUSE*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "macFUSE 4.2.4":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-12-20 15:58:39 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Benjamin Fleischer (3T5GSNBU6W)
CodeSignatureVerifier:        Expires: 2022-03-30 21:49:12 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            6F AD D6 59 BA 75 D1 0C 2F 4B 78 F5 36 56 48 A4 3F F4 68 2A 23 DC 
CodeSignatureVerifier:            25 B7 85 28 23 54 A7 06 39 A1
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
PkgCopier
{'Input': {'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse.pkg',
           'source_pkg': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/downloads/macfuse-4.2.4.dmg/Extras/macFUSE*.pkg'}}
PkgCopier: Mounted disk image /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/downloads/macfuse-4.2.4.dmg
PkgCopier: Using path '/private/tmp/dmg.iPxwpy/Extras/macFUSE 4.2.4.pkg' matched from globbed '/private/tmp/dmg.iPxwpy/Extras/macFUSE*.pkg'.
PkgCopier: Copied /private/tmp/dmg.iPxwpy/Extras/macFUSE 4.2.4.pkg to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse.pkg'}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/unpack',
           'flat_pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse.pkg'}}
FlatPkgUnpacker: Unpacked /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse.pkg to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse',
           'pkg_payload_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/unpack/Core.pkg/Payload'}}
PkgPayloadUnpacker: Unpacked /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/unpack/Core.pkg/Payload to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': [],
           'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/Filesystems/macfuse.fs',
           'requirement': 'identifier "io.macfuse.filesystems.fs.macfuse" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"3T5GSNBU6W"',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/Filesystems/macfuse.fs: valid on disk
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/Filesystems/macfuse.fs: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/Filesystems/macfuse.fs: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': [],
           'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/Frameworks/macFUSE.framework',
           'requirement': 'identifier "io.macfuse.frameworks.macfuse" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"3T5GSNBU6W"',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/Frameworks/macFUSE.framework: valid on disk
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/Frameworks/macFUSE.framework: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/Frameworks/macFUSE.framework: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse',
           'pkg_payload_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/unpack/PreferencePane.pkg/Payload'}}
PkgPayloadUnpacker: Unpacked /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/unpack/PreferencePane.pkg/Payload to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': [],
           'input_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/PreferencePanes/macFUSE.prefPane',
           'requirement': 'identifier "io.macfuse.preferencepanes.macfuse" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"3T5GSNBU6W"',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/PreferencePanes/macFUSE.prefPane: valid on disk
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/PreferencePanes/macFUSE.prefPane: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/PreferencePanes/macFUSE.prefPane: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PlistReader
{'Input': {'info_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/Filesystems/macfuse.fs/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version',
                          'LSMinimumSystemVersion': 'min_os_version'}}}
PlistReader: Reading: /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse/Library/Filesystems/macfuse.fs/Contents/Info.plist
PlistReader: Assigning value of '4.2.4' to output variable 'version'
PlistReader: Assigning value of '10.9' to output variable 'min_os_version'
{'Output': {'plist_reader_output_variables': {'min_os_version': '10.9',
                                              'version': '4.2.4'}}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse',
           'installs_item_paths': ['/Library/Filesystems/macfuse.fs',
                                   '/Library/Frameworks/macFUSE.framework']}}
MunkiInstallsItemsCreator: Created installs item for /Library/Filesystems/macfuse.fs
MunkiInstallsItemsCreator: Created installs item for /Library/Frameworks/macFUSE.framework
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleShortVersionString': '4.2.4',
                                                 'CFBundleVersion': '4.2.4',
                                                 'path': '/Library/Filesystems/macfuse.fs',
                                                 'type': 'bundle',
                                                 'version_comparison_key': 'CFBundleShortVersionString'},
                                                {'CFBundleShortVersionString': '4.2.4',
                                                 'CFBundleVersion': '4.2.4',
                                                 'path': '/Library/Frameworks/macFUSE.framework',
                                                 'type': 'bundle',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleShortVersionString': '4.2.4',
                                                'CFBundleVersion': '4.2.4',
                                                'path': '/Library/Filesystems/macfuse.fs',
                                                'type': 'bundle',
                                                'version_comparison_key': 'CFBundleShortVersionString'},
                                               {'CFBundleShortVersionString': '4.2.4',
                                                'CFBundleVersion': '4.2.4',
                                                'path': '/Library/Frameworks/macFUSE.framework',
                                                'type': 'bundle',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'catalogs': ['testing'],
                       'description': "macFUSE allows you to extend OS X's "
                                      'native file handling capabilities via '
                                      'third-party file systems. macFUSE (v4) '
                                      'is a successor to OSXFUSE (v3), which '
                                      'has been used as a software building '
                                      'block by dozens of products, but is no '
                                      'longer being maintained.',
                       'display_name': 'macFUSE',
                       'installer_choices_xml': [{'attributeSetting': 1,
                                                  'choiceAttribute': 'selected',
                                                  'choiceIdentifier': 'io.macfuse.installer.components.core'},
                                                 {'attributeSetting': 1,
                                                  'choiceAttribute': 'selected',
                                                  'choiceIdentifier': 'io.macfuse.installer.components.preferencepane'}],
                       'name': 'macfuse',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleShortVersionString': '4.2.4', 'CFBundleVersion': '4.2.4', 'path': '/Library/Filesystems/macfuse.fs', 'type': 'bundle', 'version_comparison_key': 'CFBundleShortVersionString'}, {'CFBundleShortVersionString': '4.2.4', 'CFBundleVersion': '4.2.4', 'path': '/Library/Frameworks/macFUSE.framework', 'type': 'bundle', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': "macFUSE allows you to extend OS X's "
                                       'native file handling capabilities via '
                                       'third-party file systems. macFUSE (v4) '
                                       'is a successor to OSXFUSE (v3), which '
                                       'has been used as a software building '
                                       'block by dozens of products, but is no '
                                       'longer being maintained.',
                        'display_name': 'macFUSE',
                        'installer_choices_xml': [{'attributeSetting': 1,
                                                   'choiceAttribute': 'selected',
                                                   'choiceIdentifier': 'io.macfuse.installer.components.core'},
                                                  {'attributeSetting': 1,
                                                   'choiceAttribute': 'selected',
                                                   'choiceIdentifier': 'io.macfuse.installer.components.preferencepane'}],
                        'installs': [{'CFBundleShortVersionString': '4.2.4',
                                      'CFBundleVersion': '4.2.4',
                                      'path': '/Library/Filesystems/macfuse.fs',
                                      'type': 'bundle',
                                      'version_comparison_key': 'CFBundleShortVersionString'},
                                     {'CFBundleShortVersionString': '4.2.4',
                                      'CFBundleVersion': '4.2.4',
                                      'path': '/Library/Frameworks/macFUSE.framework',
                                      'type': 'bundle',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'macfuse',
                        'unattended_install': True}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'minimum_os_version': '10.9',
                                  'version': '4.2.4'},
           'pkginfo': {'catalogs': ['testing'],
                       'description': "macFUSE allows you to extend OS X's "
                                      'native file handling capabilities via '
                                      'third-party file systems. macFUSE (v4) '
                                      'is a successor to OSXFUSE (v3), which '
                                      'has been used as a software building '
                                      'block by dozens of products, but is no '
                                      'longer being maintained.',
                       'display_name': 'macFUSE',
                       'installer_choices_xml': [{'attributeSetting': 1,
                                                  'choiceAttribute': 'selected',
                                                  'choiceIdentifier': 'io.macfuse.installer.components.core'},
                                                 {'attributeSetting': 1,
                                                  'choiceAttribute': 'selected',
                                                  'choiceIdentifier': 'io.macfuse.installer.components.preferencepane'}],
                       'installs': [{'CFBundleShortVersionString': '4.2.4',
                                     'CFBundleVersion': '4.2.4',
                                     'path': '/Library/Filesystems/macfuse.fs',
                                     'type': 'bundle',
                                     'version_comparison_key': 'CFBundleShortVersionString'},
                                    {'CFBundleShortVersionString': '4.2.4',
                                     'CFBundleVersion': '4.2.4',
                                     'path': '/Library/Frameworks/macFUSE.framework',
                                     'type': 'bundle',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'macfuse',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'minimum_os_version': '10.9', 'version': '4.2.4'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': "macFUSE allows you to extend OS X's "
                                       'native file handling capabilities via '
                                       'third-party file systems. macFUSE (v4) '
                                       'is a successor to OSXFUSE (v3), which '
                                       'has been used as a software building '
                                       'block by dozens of products, but is no '
                                       'longer being maintained.',
                        'display_name': 'macFUSE',
                        'installer_choices_xml': [{'attributeSetting': 1,
                                                   'choiceAttribute': 'selected',
                                                   'choiceIdentifier': 'io.macfuse.installer.components.core'},
                                                  {'attributeSetting': 1,
                                                   'choiceAttribute': 'selected',
                                                   'choiceIdentifier': 'io.macfuse.installer.components.preferencepane'}],
                        'installs': [{'CFBundleShortVersionString': '4.2.4',
                                      'CFBundleVersion': '4.2.4',
                                      'path': '/Library/Filesystems/macfuse.fs',
                                      'type': 'bundle',
                                      'version_comparison_key': 'CFBundleShortVersionString'},
                                     {'CFBundleShortVersionString': '4.2.4',
                                      'CFBundleVersion': '4.2.4',
                                      'path': '/Library/Frameworks/macFUSE.framework',
                                      'type': 'bundle',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'minimum_os_version': '10.9',
                        'name': 'macfuse',
                        'unattended_install': True,
                        'version': '4.2.4'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse.pkg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': "macFUSE allows you to extend OS X's "
                                      'native file handling capabilities via '
                                      'third-party file systems. macFUSE (v4) '
                                      'is a successor to OSXFUSE (v3), which '
                                      'has been used as a software building '
                                      'block by dozens of products, but is no '
                                      'longer being maintained.',
                       'display_name': 'macFUSE',
                       'installer_choices_xml': [{'attributeSetting': 1,
                                                  'choiceAttribute': 'selected',
                                                  'choiceIdentifier': 'io.macfuse.installer.components.core'},
                                                 {'attributeSetting': 1,
                                                  'choiceAttribute': 'selected',
                                                  'choiceIdentifier': 'io.macfuse.installer.components.preferencepane'}],
                       'installs': [{'CFBundleShortVersionString': '4.2.4',
                                     'CFBundleVersion': '4.2.4',
                                     'path': '/Library/Filesystems/macfuse.fs',
                                     'type': 'bundle',
                                     'version_comparison_key': 'CFBundleShortVersionString'},
                                    {'CFBundleShortVersionString': '4.2.4',
                                     'CFBundleVersion': '4.2.4',
                                     'path': '/Library/Frameworks/macFUSE.framework',
                                     'type': 'bundle',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'minimum_os_version': '10.9',
                       'name': 'macfuse',
                       'unattended_install': True,
                       'version': '4.2.4'},
           'repo_subdirectory': 'drivers/macfuse'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/drivers/macfuse/macfuse-4.2.4__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/drivers/macfuse/macfuse-4.2.4__1.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'macfuse',
                                                       'pkg_repo_path': 'drivers/macfuse/macfuse-4.2.4__1.pkg',
                                                       'pkginfo_path': 'drivers/macfuse/macfuse-4.2.4__1.plist',
                                                       'version': '4.2.4'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'autopkgadmin',
                                         'creation_date': datetime.datetime(2022, 2, 15, 5, 3, 58),
                                         'munki_version': '5.6.2.4398',
                                         'os_version': '12.2.1'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': "macFUSE allows you to extend OS X's "
                                          'native file handling capabilities '
                                          'via third-party file systems. '
                                          'macFUSE (v4) is a successor to '
                                          'OSXFUSE (v3), which has been used '
                                          'as a software building block by '
                                          'dozens of products, but is no '
                                          'longer being maintained.',
                           'display_name': 'macFUSE',
                           'installed_size': 6762,
                           'installer_choices_xml': [{'attributeSetting': 1,
                                                      'choiceAttribute': 'selected',
                                                      'choiceIdentifier': 'io.macfuse.installer.components.core'},
                                                     {'attributeSetting': 1,
                                                      'choiceAttribute': 'selected',
                                                      'choiceIdentifier': 'io.macfuse.installer.components.preferencepane'}],
                           'installer_item_hash': '95f3ba8ba76eca4ad370532d76d4f639336c47d79b01c2ca987e694ec7fdd8fd',
                           'installer_item_location': 'drivers/macfuse/macfuse-4.2.4__1.pkg',
                           'installer_item_size': 4297,
                           'installs': [{'CFBundleShortVersionString': '4.2.4',
                                         'CFBundleVersion': '4.2.4',
                                         'path': '/Library/Filesystems/macfuse.fs',
                                         'type': 'bundle',
                                         'version_comparison_key': 'CFBundleShortVersionString'},
                                        {'CFBundleShortVersionString': '4.2.4',
                                         'CFBundleVersion': '4.2.4',
                                         'path': '/Library/Frameworks/macFUSE.framework',
                                         'type': 'bundle',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.9',
                           'name': 'macfuse',
                           'receipts': [{'installed_size': 4026,
                                         'packageid': 'io.macfuse.installer.components.core',
                                         'version': '4.2.4'},
                                        {'installed_size': 2736,
                                         'packageid': 'io.macfuse.installer.components.preferencepane',
                                         'version': '4.2.4'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '4.2.4'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/drivers/macfuse/macfuse-4.2.4__1.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/drivers/macfuse/macfuse-4.2.4__1.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse',
                         '/Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/unpack']}}
PathDeleter: Deleted /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse
PathDeleter: Deleted /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/unpack
{'Output': {}}
Receipt written to /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/receipts/macfuse.munki-receipt-20220215-000358.plist

The following packages were copied:
    Pkg Path                                                                              
    --------                                                                              
    /Users/autopkgadmin/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.munki.macfuse/macfuse.pkg  

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                            Pkg Repo Path                         Icon Repo Path  
    ----     -------  --------  ------------                            -------------                         --------------  
    macfuse  4.2.4    testing   drivers/macfuse/macfuse-4.2.4__1.plist  drivers/macfuse/macfuse-4.2.4__1.pkg 
```