### PR TITLE
Update yEd.download.recipe

### DIFF
--- a/yWorks/yEd.download.recipe
+++ b/yWorks/yEd.download.recipe
@@ -10,6 +10,10 @@
     <dict>
         <key>NAME</key>
         <string>yEd</string>
+        <key>PACKAGE_ARCH</key>
+        <string>amd64</string>
+        <key>Comment</key>
+        <string>PACKAGE_ARCH should be set to "arm64" (for Apple Silicon) or "amd64" (for Intel)</string>      
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
@@ -19,9 +23,9 @@
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>\/resources\/yed\/demo\/yEd-[0-9\.]+_with-JRE[0-9][0-9]+\.dmg</string>
+                <string>\/resources\/yed\/demo\/yEd-[0-9\.]+_with-JRE[0-9][0-9]+\_%PACKAGE_ARCH%.dmg</string>
                 <key>url</key>
-                <string>https://www.yworks.com/products/yed/download</string>
+                <string>https://www.yworks.com/downloads</string>
                 <key>result_output_var_name</key>
                 <string>url_path</string>
             </dict>


### PR DESCRIPTION
- Changed the URL used to figure out download path
- Changed the `re_pattern` key in URLTextSearcher to find the new installer names
- Added the `PACKAGE_ARCH` key to allow the selection of Intel or Apple Silicon (ARM) disk images