### PR TITLE
Deprecate osxfuse recipes

### DIFF
--- a/OSXFUSE/osxfuse.download.recipe
+++ b/OSXFUSE/osxfuse.download.recipe
@@ -16,9 +16,18 @@
 	<string>true</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Please switch to the macFUSE recipes elsewhere in this repo. The osxfuse recipes are deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This pull request deprecates the non-working osxfuse recipes and points people to the macFUSE recipes instead.

If https://github.com/autopkg/48kRAM-recipes/pull/29/files is merged, consider changing the DeprecationWarning to point to apizz-recipes instead.