### PR TITLE
Fix yEd download method and support multiple architectures

### DIFF
--- a/yWorks/yEd.download.recipe
+++ b/yWorks/yEd.download.recipe
@@ -10,18 +10,33 @@
     <dict>
         <key>NAME</key>
         <string>yEd</string>
+        <key>ARCH</key>
+        <string>x86_64</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_string</key>
+                <string>%ARCH%</string>
+                <key>find</key>
+                <string>x86_64</string>
+                <key>replace</key>
+                <string>amd64</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>\/resources\/yed\/demo\/yEd-[0-9\.]+_with-JRE[0-9][0-9]+\.dmg</string>
+                <string>\/(resources\/yed\/demo\/yEd-[\d\.]+_with-JRE\d+_%output_string%\.dmg)</string>
                 <key>url</key>
-                <string>https://www.yworks.com/products/yed/download</string>
+                <string>https://www.yworks.com/downloads#yEd</string>
                 <key>result_output_var_name</key>
                 <string>url_path</string>
             </dict>
@@ -34,7 +49,7 @@
                 <key>url</key>
                 <string>https://www.yworks.com/%url_path%</string>
                 <key>filename</key>
-                <string>%NAME%.dmg</string>
+                <string>%NAME%-%ARCH%.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/yWorks/yEd.munki.recipe
+++ b/yWorks/yEd.munki.recipe
@@ -24,6 +24,10 @@
             <string>yEd</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%ARCH%</string>
+            </array>
             <key>unattended_install</key>
             <true/>
         </dict>


### PR DESCRIPTION
This pull request adjusts the download method for yEd and enables support for multiple architectures using an input variable.

Download recipe verbose run log with default architecture:

```
% autopkg run -vvq yWorks/yEd.download.recipe 
Processing yWorks/yEd.download.recipe...
WARNING: yWorks/yEd.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.homebysix.FindAndReplace/FindAndReplace
{'Input': {'find': 'x86_64', 'input_string': 'x86_64', 'replace': 'amd64'}}
FindAndReplace: Replacing "x86_64" with "amd64" in "x86_64".
{'Output': {'output_string': 'amd64'}}
URLTextSearcher
{'Input': {'re_pattern': '\\/(resources\\/yed\\/demo\\/yEd-[\\d\\.]+_with-JRE\\d+_amd64\\.dmg)',
           'result_output_var_name': 'url_path',
           'url': 'https://www.yworks.com/downloads#yEd'}}
URLTextSearcher: Found matching text (url_path): resources/yed/demo/yEd-3.24_with-JRE21_amd64.dmg
{'Output': {'url_path': 'resources/yed/demo/yEd-3.24_with-JRE21_amd64.dmg'}}
URLDownloader
{'Input': {'filename': 'yEd-x86_64.dmg',
           'url': 'https://www.yworks.com/resources/yed/demo/yEd-3.24_with-JRE21_amd64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.download.yed/downloads/yEd-x86_64.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.download.yed/downloads/yEd-x86_64.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.download.yed/downloads/yEd-x86_64.dmg/yEd.app',
           'requirement': 'identifier "com.yworks.yEd" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'JD89S887M2'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.download.yed/downloads/yEd-x86_64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.eOLmn3/yEd.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.eOLmn3/yEd.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.eOLmn3/yEd.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.download.yed/receipts/yEd.download-receipt-20241224-132155.plist

Nothing downloaded, packaged or imported.
```

Download recipe verbose run log with `arm64` specified:

```
% autopkg run -vvq yWorks/yEd.download.recipe -k ARCH=arm64
Processing yWorks/yEd.download.recipe...
WARNING: yWorks/yEd.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.homebysix.FindAndReplace/FindAndReplace
{'Input': {'find': 'x86_64', 'input_string': 'arm64', 'replace': 'amd64'}}
FindAndReplace: Replacing "x86_64" with "amd64" in "arm64".
{'Output': {'output_string': 'arm64'}}
URLTextSearcher
{'Input': {'re_pattern': '\\/(resources\\/yed\\/demo\\/yEd-[\\d\\.]+_with-JRE\\d+_arm64\\.dmg)',
           'result_output_var_name': 'url_path',
           'url': 'https://www.yworks.com/downloads#yEd'}}
URLTextSearcher: Found matching text (url_path): resources/yed/demo/yEd-3.24_with-JRE21_arm64.dmg
{'Output': {'url_path': 'resources/yed/demo/yEd-3.24_with-JRE21_arm64.dmg'}}
URLDownloader
{'Input': {'filename': 'yEd-arm64.dmg',
           'url': 'https://www.yworks.com/resources/yed/demo/yEd-3.24_with-JRE21_arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.download.yed/downloads/yEd-arm64.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.download.yed/downloads/yEd-arm64.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.download.yed/downloads/yEd-arm64.dmg/yEd.app',
           'requirement': 'identifier "com.yworks.yEd" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'JD89S887M2'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.download.yed/downloads/yEd-arm64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.GZo9eA/yEd.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.GZo9eA/yEd.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.GZo9eA/yEd.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.48kRAM.autopkg.download.yed/receipts/yEd.download-receipt-20241224-132206.plist

Nothing downloaded, packaged or imported.
```

Disregard if https://github.com/autopkg/48kRAM-recipes/pull/35 is merged.